### PR TITLE
Use Statically CDN for Content URLs instead of Requesting Directly to Raw GitHub

### DIFF
--- a/lua/neo-chatsounds/data.lua
+++ b/lua/neo-chatsounds/data.lua
@@ -8,12 +8,14 @@ data.Lookup = data.Lookup or {
 	Dynamic = {},
 }
 
-local function BUILD_CONTENT_URL(repo, branch, path)
-	-- just github
-	return ("https://raw.githubusercontent.com/%s/%s/%s"):format(repo, branch, path)
+local CDN_USE_FALLBACK = CreateConVar("chatsounds_cdn_use_fallback", "0", FCVAR_ARCHIVE, "Use fallback CDN for chatsounds, this is useful if getting from github directly is not working (requires a reload!)", 0, 1)
 
-	-- jsdeliver
-	--return ("https://cdn.jsdelivr.net/gh/%s@%s/%s"):format(repo, branch, path)
+local function BUILD_CONTENT_URL(repo, branch, path)
+	if CDN_USE_FALLBACK:GetBool() then
+		return ("https://cdn.statically.io/gh/%s/%s/%s"):format(repo, branch, path)
+	else
+		return ("https://raw.githubusercontent.com/%s/%s/%s"):format(repo, branch, path)
+	end
 end
 
 function data.CacheRepository(repo, branch, path)

--- a/lua/neo-chatsounds/data.lua
+++ b/lua/neo-chatsounds/data.lua
@@ -8,14 +8,8 @@ data.Lookup = data.Lookup or {
 	Dynamic = {},
 }
 
-local CDN_USE_FALLBACK = CreateConVar("chatsounds_cdn_use_fallback", "0", FCVAR_ARCHIVE, "Use fallback CDN for chatsounds, this is useful if getting from github directly is not working (requires a reload!)", 0, 1)
-
 local function BUILD_CONTENT_URL(repo, branch, path)
-	if CDN_USE_FALLBACK:GetBool() then
-		return ("https://cdn.statically.io/gh/%s/%s/%s"):format(repo, branch, path)
-	else
-		return ("https://raw.githubusercontent.com/%s/%s/%s"):format(repo, branch, path)
-	end
+	return ("https://cdn.statically.io/gh/%s/%s/%s"):format(repo, branch, path)
 end
 
 function data.CacheRepository(repo, branch, path)


### PR DESCRIPTION
There might be some edge cases where raw.githubusercontent.com would be too slow since its returning the raw file without caching it from the GitHub API for some players. This uses [statically](https://statically.io) CDN to fetch the files instead of requesting everything to raw.githubusercontent.com.

![image](https://github.com/user-attachments/assets/421ac443-447f-408a-ba2b-a7c8f399ed01)
