### PR TITLE
do not queue chatsounds if webaudio has not finished loading

### DIFF
--- a/lua/neo-chatsounds/dependencies/webaudio.lua
+++ b/lua/neo-chatsounds/dependencies/webaudio.lua
@@ -111,6 +111,10 @@ function webaudio.Shutdown()
 	hook.Remove("Think", "webaudio2")
 end
 
+function webaudio.HasInitialized()
+	return webaudio.browser_state == "initialized"
+end
+
 function webaudio.Initialize()
 	if webaudio.browser_state ~= "uninitialized" then return end
 
@@ -932,10 +936,12 @@ do
 
 	function META:UpdateVolume()
 		queue_javascript()
-		if self:Get3D() then
-			self:UpdateVolume3d()
-		else
-			self:UpdateVolumeFlat()
+		if webaudio.HasInitialized() then
+			if self:Get3D() then
+				self:UpdateVolume3d()
+			else
+				self:UpdateVolumeFlat()
+			end
 		end
 		execute_javascript()
 	end

--- a/lua/neo-chatsounds/player.lua
+++ b/lua/neo-chatsounds/player.lua
@@ -549,6 +549,7 @@ if CLIENT then
 			t:resolve()
 			return t
 		end
+		
 
 		local tasks = {}
 		local text_chunks = text:Split(CONTEXT_SEPARATOR)
@@ -557,6 +558,11 @@ if CLIENT then
 			chatsounds.Parser.ParseAsync(chunk):next(function(sound_group)
 				local ret = hook.Run("ChatsoundsShouldPlay", ply, chunk, sound_group)
 				if ret == false then
+					t:resolve()
+					return
+				end
+				if not chatsounds.WebAudio.HasInitialized() then
+					-- no point in queueing if the webaudio cannot load
 					t:resolve()
 					return
 				end


### PR DESCRIPTION
Also adds webaudio.HasInitialized()

Tested to still play chatsounds and didn't at least error when tested with broken CEF.